### PR TITLE
docs: Remove "4G" from Galaxy A72 device name

### DIFF
--- a/docs/official_devices/list.md
+++ b/docs/official_devices/list.md
@@ -32,7 +32,7 @@ sidebar_class_name: hidden
 
 - [Galaxy M34 5G / Galaxy F34 (m34x)](/devices/m34x)
 - [Galaxy A52 4G (a52q)](/devices/a52q)
-- [Galaxy A72 4G (a72q)](/devices/a72q)
+- [Galaxy A72 (a72q)](/devices/a72q)
 - [Galaxy S20 FE 5G (r8q)](/devices/r8q)
 - [Galaxy S20 FE 4G (r8s)](/devices/r8s)
 

--- a/docs/official_devices/samsung/a72q.md
+++ b/docs/official_devices/samsung/a72q.md
@@ -2,16 +2,16 @@
 slug: /devices/a72q
 pagination_next: null
 pagination_prev: null
-title: "Samsung Galaxy A72 4G (a72q)"
+title: "Samsung Galaxy A72 (a72q)"
 ---
 
-# Samsung Galaxy A72 4G (a72q)
+# Samsung Galaxy A72 (a72q)
 
 :::info
 
 ## Device Information
 
-- **Device:** Samsung Galaxy A72 4G
+- **Device:** Samsung Galaxy A72
 - **Release Date:** March 17, 2021
 - **Chipset:** 	Qualcomm SM7125 Snapdragon 720G
 - **RAM:** 6GB / 8GB


### PR DESCRIPTION
Galaxy A72 was only released in a 4G variant, as the planned 5G model was never released, making the "4G" suffix unnecessary in the documentation.